### PR TITLE
Create complex example

### DIFF
--- a/test/features/complex_example_test.rb
+++ b/test/features/complex_example_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+require 'yaml'
+
+class ComplexExampleTest < Capybara::Rails::TestCase
+  include Warden::Test::Helpers
+  after { Warden.test_reset! }
+
+  test "complex service" do
+    swagger = YAML.load_file("#{Rails.root}/test/files/sample-services/ComplexExample.yaml")
+    url_complex_example = swagger['host']+swagger['basePath']+swagger['paths'].keys.first
+    visit "#{swagger['schemes'].first}://#{url_complex_example}"
+    assert_content 'pedro@dominio.com'
+    assert_content 'Juan Andres'
+    assert_content 'Perez Cortez'    
+  end
+
+end

--- a/test/features/complex_example_test.rb
+++ b/test/features/complex_example_test.rb
@@ -6,6 +6,7 @@ class ComplexExampleTest < Capybara::Rails::TestCase
   after { Warden.test_reset! }
 
   test "complex service" do
+    skip("Skiped because use external rest service")
     swagger = YAML.load_file("#{Rails.root}/test/files/sample-services/ComplexExample.yaml")
     url_complex_example = swagger['host']+swagger['basePath']+swagger['paths'].keys.first
     visit "#{swagger['schemes'].first}://#{url_complex_example}"

--- a/test/features/test_complex_example_test.rb
+++ b/test/features/test_complex_example_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require 'yaml'
+
+class TestSimpleExampleTest < Capybara::Rails::TestCase
+  include Warden::Test::Helpers
+  after { Warden.test_reset! }
+
+  setup do
+    login_as users(:pablito), scope: :user
+    visit root_path
+    find('#user-menu').click
+    find_link('services').click
+    find_link('Crear Servicio').click
+    fill_in 'service_name', :with => "Compex Test"
+    page.execute_script('$("input[type=file]").show()')
+  end
+
+  test "complex service example" do
+    attach_file 'service_spec_file', Rails.root.join(
+      'test', 'files', 'sample-services', 'ComplexExample.yaml')
+
+    click_button "Crear Servicio"
+    assert_content page, "Servicio creado correctamente"
+
+    click_button "Probar Servicio"
+    within ".console" do
+      click_button "Enviar"
+      assert_content 'pedro@dominio.com'
+      assert_content 'Juan Andres'
+      assert_content 'Perez Cortez'
+    end
+
+  end
+
+end

--- a/test/files/sample-services/ComplexExample.yaml
+++ b/test/files/sample-services/ComplexExample.yaml
@@ -1,0 +1,66 @@
+swagger: '2.0'
+info:
+  description: |
+    Este es un ejemplo complejo para Interoperabilidad 
+  version: 0.0.1
+  title: Servicio Complejo de Referencia
+  contact:
+    email: contacto@interoperabilidad.digital.gob.cl
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+schemes:
+  - http
+host: 172.16.0.110:9494
+basePath: /complex_example
+
+paths:
+  /personas:
+    get:
+      summary: Listado de personas
+      operationId: peopleIndex
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/people'
+
+definitions:
+  nombreyapellido:
+    type: object
+    required:
+      - nombres
+      - apellidos
+    properties:
+      nombres:
+        type: string
+      apellidos:
+        type: string
+  telefono:
+    type: number
+    minimum: 111111
+  datos:
+    type: object
+    properties:
+      telefonos:
+        type: array
+        items:
+          $ref: '#/definitions/telefono'
+      email:
+        type: string
+        format: email
+  people:
+    type: object
+    required:
+      - persona
+    properties:
+      persona:
+        $ref: '#/definitions/nombreyapellido'
+      datos:
+        $ref: '#/definitions/datos'

--- a/test/files/sample-services/ComplexExample.yaml
+++ b/test/files/sample-services/ComplexExample.yaml
@@ -11,7 +11,7 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 schemes:
   - http
-host: 172.16.0.110:9494
+host: complex-service-interop.herokuapp.com
 basePath: /complex_example
 
 paths:


### PR DESCRIPTION
- It was created a YAML swagger [file](test/files/sample-services/ComplexExample.yaml) to test teh complex service.

- It was created a external [service](http://complex-service-interop.herokuapp.com/complex_example/personas) that satisface the test complex service.

- It was created a simple test for the external service, but it was disabled because it can broke the deploy.

- It was created the feature test for the user history.