### PR TITLE
Change Claveúnica scope

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   APP_ID = ENV['ROLE_APP_ID']
 
   def self.from_omniauth(auth)
-    rut = auth.extra.raw_info.RUT
+    rut = auth.extra.raw_info.RolUnico.numero.to_s + '-' + auth.extra.raw_info.RolUnico.DV
     sub = auth.extra.raw_info.sub
     id_token = auth.credentials.id_token
     new_user = where(rut: rut).first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   APP_ID = ENV['ROLE_APP_ID']
 
   def self.from_omniauth(auth)
-    rut = auth.extra.raw_info.RolUnico.numero.to_s + '-' + auth.extra.raw_info.RolUnico.DV
+    rut = self.rut_with_separator(auth.extra.raw_info.RolUnico)
     sub = auth.extra.raw_info.sub
     id_token = auth.credentials.id_token
     new_user = where(rut: rut).first
@@ -29,6 +29,11 @@ class User < ApplicationRecord
     end
     new_user.refresh_user_roles_and_email(auth.extra.raw_info)
     new_user
+  end
+
+  def self.rut_with_separator(rut_object)
+    rut = rut_object.numero.to_s.reverse.scan(/\d{3}|.+/).join(".").reverse
+    rut + "-" + rut_object.DV
   end
 
   def refresh_user_roles_and_email(raw_info)
@@ -48,7 +53,7 @@ class User < ApplicationRecord
     self.roles.delete_all
     self.can_create_schemas = false
     if response.nil? || response.has_key?('nada')
-      self.name = raw_info.nombres + ' ' + raw_info.apellidoPaterno + ' ' + raw_info.apellidoMaterno
+      self.name = raw_info.name.nombres.join(' ') + ' ' + raw_info.name.apellidos.join(' ')
     else
       self.name = refresh_name(response['nombre'])
       response['instituciones'].each do |organization|

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -242,7 +242,7 @@ Devise.setup do |config|
   OmniAuth.config.full_host = ENV["OP_CALLBACK_URL"]
   config.omniauth :openid_connect, {
     name: :clave_unica,
-    scope: [:openid, :nombre],
+    scope: [:openid, :run, :name],
     response_type: :code,
     discovery: true,
     send_nonce: false,

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,7 +6,7 @@ class UserTest < ActiveSupport::TestCase
     user = users(:perico)
     segpres = organizations(:segpres)
     auth = Hashie::Mash.new(
-      extra: {raw_info: {"RUT" => "22.222.222-2", "sub" => "8", "nombres" => "Perico", "apellidoPaterno" => "de los", "apellidoMaterno" => "Palotes"}},
+      extra: {raw_info: {RolUnico: {"numero" => 22222222, "DV" => "2", "tipo" => "RUN"}, "sub" => "8", name:{"nombres" => ["Perico"], "apellidos" => ["de", "los", "Palotes"]}}},
       credentials: {id_token: "ASDF"}
     )
     user.refresh_user_roles_and_email(auth.extra.raw_info)
@@ -17,7 +17,7 @@ class UserTest < ActiveSupport::TestCase
 
   test '.from_omniauth sets Auth params to new user' do
     auth = Hashie::Mash.new(
-      extra: {raw_info: {"RUT" => "55.555.555-5", "sub" => "8", "nombres" => "Perico", "apellidoPaterno" => "de los", "apellidoMaterno" => "Palotes"}},
+      extra: {raw_info: {RolUnico:{"numero" => 55555555, "DV" => "5", "tipo" => "RUN"}, "sub" => "8", name:{"nombres" => ["Perico"], "apellidos" => ["de", "los", "Palotes"]}}},
       credentials: {id_token: "ASDF"}
     )
     User.from_omniauth(auth)
@@ -34,7 +34,7 @@ class UserTest < ActiveSupport::TestCase
 
   test '.from_omniauth sets Auth params to existing user' do
     auth = Hashie::Mash.new(
-      extra: {raw_info: {"RUT" => "11.111.111-1", "sub" => "8", "nombres" => "Perico", "apellidoPaterno" => "de los", "apellidoMaterno" => "Palotes"}},
+      extra: {raw_info: {RolUnico:{"numero" => 11111111, "DV" => "1", "tipo" => "RUN"}, "sub" => "8", name:{"nombres" => ["Perico"], "apellidos" => ["de", "los", "Palotes"]}}},
       credentials: {id_token: "ASDF"}
     )
     user = User.where(rut: "11.111.111-1").first


### PR DESCRIPTION
Apply changes to the Scope of clave unica, and adopt the new JSON response from the login service.

Also, update the corresponding test.