### PR TITLE
Fix monitor worker exception handling.

### DIFF
--- a/app/workers/service_version_monitor_worker.rb
+++ b/app/workers/service_version_monitor_worker.rb
@@ -3,14 +3,13 @@ class ServiceVersionMonitorWorker
 
   def perform(service_version_id)
     service_version = ServiceVersion.find(service_version_id)
-    unless service_version
-      Rails.logger.warn("ServiceVersionMonitorWorker: Service version #{service_version_id} not found")
-      return
-    end
-    unless service_version.current?
+    if service_version.current?
+      service_version.perform_health_check!
+    else
       Rails.logger.warn("ServiceVersionMonitorWorker: Service version #{service_version_id} not current and shouldn't be monitored")
-      return
     end
-    service_version.perform_health_check!
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.warn("ServiceVersionMonitorWorker: Service version #{service_version_id} not found")
+    return
   end
 end

--- a/test/features/show_monitoring_service_detail_test.rb
+++ b/test/features/show_monitoring_service_detail_test.rb
@@ -36,9 +36,11 @@ class ShowMonitoringServiceDetailTest < Capybara::Rails::TestCase
   test "Filter/Search on the table " do
     visit root_path
     click_link "Monitoreo"
-    find('a', text: 'Servicio de Impuestos Internos')
+    assert_content "Institución"
+    assert_content "Total Servicios"
+    assert_content "Servicios no disponibles"
+    assert_content "Servicios sin monitoreo"
     click_link "Servicio de Impuestos Internos"
-    find('h2', text: 'Monitoreo > Servicio de Impuestos Internos')
     find('[placeholder="Buscar por nombre"]').set('simple')
     assert_content "SimpleService"
     find('[placeholder="Buscar por nombre"]').set('ahoranodeberiasalirnada')

--- a/test/workers/service_version_monitor_worker_test.rb
+++ b/test/workers/service_version_monitor_worker_test.rb
@@ -17,4 +17,16 @@ class ServiceVersionMonitorWorkerTest < Minitest::Test
     ServiceVersionMonitorWorker.new.perform(-1)
     assert true # Nothing raised
   end
+
+  def test_monitor_non_current_service_version
+    service_version_mock = Minitest::Mock.new
+    service_version_mock.expect :current?, false
+    ServiceVersion.stub :find, -> (id) {
+      assert_equal 42,  id
+      service_version_mock
+    } do
+      ServiceVersionMonitorWorker.new.perform(42)
+    end
+    assert_mock service_version_mock
+  end
 end

--- a/test/workers/service_version_monitor_worker_test.rb
+++ b/test/workers/service_version_monitor_worker_test.rb
@@ -12,4 +12,9 @@ class ServiceVersionMonitorWorkerTest < Minitest::Test
     end
     assert_mock service_version_mock
   end
+
+  def test_monitor_non_existing_service_version
+    ServiceVersionMonitorWorker.new.perform(-1)
+    assert true # Nothing raised
+  end
 end


### PR DESCRIPTION
When a record doesn't exist we should catch the exception instead of
expecting nil