### PR TITLE
Adds traceability menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Production should run the latest [`egob/interoperabilidad`](https://hub.docker.c
 
 - `AGREEMENT_CLIENT_TOKEN_EXPIRATION_IN_SECONDS`: Time to live for auth client tokens given to consumers after an agreement is signed to use protected services.
 
+- `TRACEABILITY_ENDPOINT`: Address of the traceability dashboard
+
 You can also set the `PORT` environment variable to change the port where the web server will listen (defaults to 80). See `config/puma.rb` for more options you can tune/override via environment variables.
 
 Putting it all together, after building the image you can run it like this:

--- a/app/assets/stylesheets/partials/layout/_header.scss
+++ b/app/assets/stylesheets/partials/layout/_header.scss
@@ -78,7 +78,7 @@ header {
     @media only screen and (min-width: 768px) {
         nav {
             .principal {
-                margin-left: 10%;
+                margin-left: 0;
                 li {
                     height: 118px;
                     width: 160px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,8 @@ class ApplicationController < ActionController::Base
   def new_session_path(scope)
     new_user_session_path
   end
+
+  def traceability_endpoint
+    ENV['TRACEABILITY_ENDPOINT']
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,6 +42,8 @@
                       =active_link_to t(:schemas), schemas_path, :active => [['schemas', 'schema_versions'],[]]
                     %li{:role => "presentation"}
                       =active_link_to t(:monitoring), monitoring_organizations_path
+                    %li{role: "presentation"}
+                      =link_to t(:traceability), controller.traceability_endpoint
                   .nav.navbar-nav.navbar-right
                     =render 'layouts/menu'
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -516,3 +516,4 @@ es:
   service_versions_changelog: Descripción de Cambios
   service_version_proposed_changes: Cambios
   supports_xml: Soporta XML
+  traceability: Trazabilidad

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - REDIS_URL=redis://redis
       - BUNDLE_PATH=${BUNDLE_PATH-/usr/local/bundle/}
       - URL_MOCK_SERVICE=https://swagger-mocks.herokuapp.com
+      - TRACEABILITY_ENDPOINT=http://dashboard.digital.gob.cl/
   web:
     <<: *base
     tty: true


### PR DESCRIPTION
- Adds TRACEABILITY_ENDPOINT env variable
- Add link that uses the TRACEABILITY_ENDPOINT on the main menu to redirect to
the traceability dashboard
- Reduces left margin on main menu to make space for the Trazabilidad
button